### PR TITLE
fix bcalc recursion

### DIFF
--- a/include/metapod/tools/bcalc.hh
+++ b/include/metapod/tools/bcalc.hh
@@ -51,10 +51,9 @@ namespace metapod
     static void run(const confVector & q)
     {
       Node::Body::iX0 = Node::Joint::sXp;
-
-      bcalc_internal< typename Node::Child1, confVector >::run(q);
-      bcalc_internal< typename Node::Child2, confVector >::run(q);
-      bcalc_internal< typename Node::Child3, confVector >::run(q);
+      bcalc_internal< typename Node::Child1, confVector, true >::run(q);
+      bcalc_internal< typename Node::Child2, confVector, true >::run(q);
+      bcalc_internal< typename Node::Child3, confVector, true >::run(q);
     }
   };
 
@@ -66,18 +65,21 @@ namespace metapod
     static void run(const confVector & q)
     {
       Node::Body::iX0 = Node::Joint::sXp * Node::Body::Parent::iX0;
-
-      bcalc_internal< typename Node::Child1, confVector >::run(q);
-      bcalc_internal< typename Node::Child2, confVector >::run(q);
-      bcalc_internal< typename Node::Child3, confVector >::run(q);
+      bcalc_internal< typename Node::Child1, confVector, true >::run(q);
+      bcalc_internal< typename Node::Child2, confVector, true >::run(q);
+      bcalc_internal< typename Node::Child3, confVector, true >::run(q);
     }
   };
 
-  template< typename confVector > struct bcalc_internal< NC, confVector >
+  template< typename confVector > struct bcalc_internal< NC, confVector, false >
   {
     static void run(const confVector &) {}
   };
 
+  template< typename confVector > struct bcalc_internal< NC, confVector, true >
+  {
+    static void run(const confVector &) {}
+  };
 } // end of namespace metapod
 
 # endif


### PR DESCRIPTION
bcalc is currently not used in the project, but is useful when one needs
to get the position of the body frames in the world frame.

However, the implementation was flawed: all bodies were treated like the
root of the tree. This patch fixes that problem.

An automated test should follow
