### PR TITLE
fix test_crba: load q.conf

### DIFF
--- a/tests/use_model/test_crba.cc
+++ b/tests/use_model/test_crba.cc
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE (test_crba)
 {
   // set configuration vector q to reference value.
   Robot::confVector q;
-  std::ifstream qconf(TEST_DIRECTORY "q.conf");
+  std::ifstream qconf(TEST_DIRECTORY "/q.conf");
   initConf< Robot >::run(qconf, q);
   qconf.close();
 


### PR DESCRIPTION
q.conf was not loaded, so the generalized mass matrix was not
computed with the robot in the expected configuration

The test_crba now fails on simple_humanoid. Do you have real reference values that we could check against somewhere?

Or should I simply update these reference values?
