### PR TITLE
Add children 0 and 4 to printTransform

### DIFF
--- a/include/metapod/tools/print.hh
+++ b/include/metapod/tools/print.hh
@@ -103,9 +103,11 @@ void printTransforms(std::ostream & os)
      << Node::Body::iX0.r().transpose() << "\n"
      << std::endl;
 
+  printTransforms<typename Node::Child0>(os);
   printTransforms<typename Node::Child1>(os);
   printTransforms<typename Node::Child2>(os);
   printTransforms<typename Node::Child3>(os);
+  printTransforms<typename Node::Child4>(os);
 }
 
 template<>


### PR DESCRIPTION
While merging branches 'add_children' and 'test_bcalc'
(commit 077e9614b8aa81d5677f27195dc4535a2e9a42d1), the printTransforms
method had not the children added. This commit adds them.
