### PR TITLE
fix single precision support

### DIFF
--- a/include/metapod/tools/fwd.hh
+++ b/include/metapod/tools/fwd.hh
@@ -41,6 +41,7 @@ namespace metapod
 
   typedef Eigen::Matrix< FloatType, Eigen::Dynamic, Eigen::Dynamic > matrixN;
   typedef Eigen::Matrix< FloatType, Eigen::Dynamic, 1 > vectorN;
+  typedef Eigen::AngleAxis< FloatType > AngleAxisd;
 
   class NC;
 }

--- a/include/metapod/tools/jointmacros.hh
+++ b/include/metapod/tools/jointmacros.hh
@@ -66,7 +66,7 @@ namespace metapod
       FloatType angle = qi[0];                                      \
       matrix3d localR;                                              \
       localR =                                                      \
-          Eigen::AngleAxisd(-angle, vector3d(axisx, axisy, axisz)); \
+          AngleAxisd(-angle, vector3d(axisx, axisy, axisz));        \
       Xj = Spatial::Transform(localR, vector3d::Zero());            \
       sXp = Xj*Xt;                                                  \
     }                                                               \

--- a/tests/common.hh
+++ b/tests/common.hh
@@ -98,7 +98,7 @@ void compareLogs(
     const std::string& reference_file,
     double epsilon)
 {
-  metapod::FloatType result_value, reference_value;
+  double result_value, reference_value;
   std::string name;
   std::string result_string, reference_string;
   std::ifstream result_stream(result_file.c_str());


### PR DESCRIPTION
With this fix, all tests continue to pass with double precision.
They also all pass with single precision, with the exception of
test_jac_point, which requires epsilon to be dropped from 1e-8
to 1e-4 to pass again.
