### PR TITLE
remove EIGEN_DEFAULT_TO_ROW_MAJOR

### DIFF
--- a/include/metapod/tools/fwd.hh
+++ b/include/metapod/tools/fwd.hh
@@ -25,13 +25,12 @@
 #ifndef METAPOD_FORWARD_HH
 # define METAPOD_FORWARD_HH
 
-# define EIGEN_DEFAULT_TO_ROW_MAJOR
 # include "Eigen/Dense"
 
 namespace metapod
 {
   typedef double FloatType;
-  
+
   typedef Eigen::Matrix< FloatType, 1, 1 > vector1d;
   typedef Eigen::Matrix< FloatType, 3, 1 > vector3d;
   typedef Eigen::Matrix< FloatType, 6, 1 > vector6d;


### PR DESCRIPTION
See http://eigen.tuxfamily.org/bz/show_bug.cgi?id=422 for background.

The performaces are unchanged, except for crba which is slightly faster
(11%) and jac_point_robot which is slower (22% for 31 dofs, 31% for 63
dofs).

This commit fixes #15 (disregarding the jac_point performance regression).

Following are the raw numbers.

With the #define (before this commit):

```
Model NBDOF : 31
    average execution time :
jcalc: 2.09801µs
bcalc: 2.79244µs
rnea: 6.23396µs
rnea (without jcalc): 3.98461µs
crba: 8.04819µs
crba (without jcalc): 5.70831µs
jac_point_robot (without bcalc): 9.4753µs

*************
Model NBDOF : 63
    average execution time :
jcalc: 4.36214µs
bcalc: 5.86329µs
rnea: 14.0243µs
rnea (without jcalc): 8.87873µs
crba: 19.0879µs
crba (without jcalc): 13.9338µs
jac_point_robot (without bcalc): 32.9601µs
```

Without the #define (after this commit):

```
Model NBDOF : 31
    average execution time :
jcalc: 2.09162µs
bcalc: 2.79224µs
rnea: 6.20565µs
rnea (without jcalc): 3.99815µs
crba: 7.31568µs
crba (without jcalc): 5.02559µs
jac_point_robot (without bcalc): 11.5705µs

*************
Model NBDOF : 63
    average execution time :
jcalc: 4.44875µs
bcalc: 5.85784µs
rnea: 14.1552µs
rnea (without jcalc): 8.9347µs
crba: 17.6304µs
crba (without jcalc): 12.4342µs
jac_point_robot (without bcalc): 43.175µs
```
