### PR TITLE
choose STATIC_ASSERT implementation automatically

### DIFF
--- a/include/metapod/tools/common.hh
+++ b/include/metapod/tools/common.hh
@@ -27,6 +27,7 @@
 
 # include "metapod/tools/fwd.hh"
 # include "metapod/config.hh"
+# include "metapod/tools/static_assert.hh"
 # include "metapod/tools/jointmacros.hh"
 # include "metapod/tools/spatial.hh"
 # include "metapod/tools/bcalc.hh"
@@ -37,12 +38,6 @@
 namespace metapod
 {
   #define GRAVITY_CST 9.81
-
-  #ifdef USE_C11_STATIC_ASSERT 
-    #define METAPOD_STATIC_ASSERT(x,msg) static_assert(x,msg)
-  #else
-    #define METAPOD_STATIC_ASSERT(x,msg) BOOST_STATIC_ASSERT_MSG(x,msg)
-  #endif
 
   inline Spatial::Motion set_gravity()
   {

--- a/include/metapod/tools/static_assert.hh
+++ b/include/metapod/tools/static_assert.hh
@@ -1,0 +1,43 @@
+// Copyright 2013,
+//
+// Olivier Stasse (JRL/LAAS, CNRS/AIST)
+// Sébastien Barthélémy (Aldébaran Robotics)
+//
+// This file is part of metapod.
+// metapod is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// metapod is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// You should have received a copy of the GNU Lesser General Public License
+// along with metapod.  If not, see <http://www.gnu.org/licenses/>.
+
+/*
+ * This file contains the includes and class definitions necessary for the
+ * whole project.
+ */
+
+#ifndef METAPOD_STATIC_ASSERT_HH
+# define METAPOD_STATIC_ASSERT_HH
+
+# include <boost/config.hpp>
+# include <boost/version.hpp>
+
+# if (__cplusplus > 199711L) || !defined(BOOST_NO_STATIC_ASSERT)
+// we use either a fully C++11 compliant compiler or one which supports the
+// static_assert feature
+#  define METAPOD_STATIC_ASSERT(x, msg) static_assert(x, msg)
+# elif BOOST_VERSION > 104000
+// use the one from boost. We got reports of problems with version 1.40,
+// which was used in ubuntu 10.04, we thus avoid it.
+#  define METAPOD_STATIC_ASSERT(x, msg) BOOST_STATIC_ASSERT_MSG(x, msg)
+# else
+// no-op implementation
+#  define METAPOD_STATIC_ASSERT(x, msg)
+# endif
+
+#endif


### PR DESCRIPTION
This commit removes the need for the USE_C11_STATIC_ASSERT option.

This option is annoying because
- it is one more option to deal with
- it is not prefixed with METAPOD
- C11 is can lead to confusions with the C version [1], CXX11 would
  have been better.

With this commit the compiler support for C++11-like static assert is
inferred from 1) the __cplusplus version 2) the boost config library.

I checked that with gcc 4.6.3 and boost 1.50, it is able to detect when
the -std=c++0x is provided or not to gcc.

If such support is detected, it is used.

If it is not available, but boost >1.40 is, boost implementation is used
instead.

(Olivier reports that version 1.40 does not work, a link to a changelog or a
bug report is welcome).

Otherwise a no-op implementation is defined.

This commit adds a dependancy on boost. Since we will soon depend on boost
fusion anyway, I think it is ok.

[1] http://en.wikipedia.org/wiki/C11_%28C_standard_revision%29
