### PR TITLE
spatial: remove OperatorMul and cleanup operators

### DIFF
--- a/include/metapod/tools/fwd.hh
+++ b/include/metapod/tools/fwd.hh
@@ -63,15 +63,6 @@ namespace metapod
       m(2,0) = -v(1);m(2,1)=  v(0) ; m(2,2) =  0 ;
       return m;
     }
-
-    // Template for operator * with inertia Matrix I
-    // T = I * S
-    template <class T, class U, class S>
-    class OperatorMul
-    {
-    public:
-      T mul(const U &u, const S &s) const;
-    };
   } // end of namespace Spatial
 
 }

--- a/include/metapod/tools/spatial/cm-anyaxis.hh
+++ b/include/metapod/tools/spatial/cm-anyaxis.hh
@@ -54,30 +54,21 @@ namespace metapod
       return tmp;
     }
 
-    template<> inline
-    Vector6d OperatorMul< Vector6d, Inertia, ConstraintMotionAnyAxis>::
-      mul(const Inertia & m,
-          const ConstraintMotionAnyAxis &a) const
+    inline Vector6d operator*(const Inertia& m,
+                              const ConstraintMotionAnyAxis& a)
     {
       Vector6d r;
-      const Vector6d & altI = m.m_I.m_ltI;
-      r[0] = altI(0)*a.S()[0]+ altI(1)*a.S()[1]+ altI(3)*a.S()[2];
-      r[1] = altI(1)*a.S()[0]+ altI(2)*a.S()[1]+ altI(4)*a.S()[2];
-      r[2] = altI(3)*a.S()[0]+ altI(4)*a.S()[1]+ altI(5)*a.S()[2];
+      const Vector6d &altI = m.I().m_ltI;
+      r[0] = altI(0)*a.S()[0] + altI(1)*a.S()[1] + altI(3)*a.S()[2];
+      r[1] = altI(1)*a.S()[0] + altI(2)*a.S()[1] + altI(4)*a.S()[2];
+      r[2] = altI(3)*a.S()[0] + altI(4)*a.S()[1] + altI(5)*a.S()[2];
 
-      Matrix3d msh = -skew(m.m_h);
-      for(unsigned int i=0;i<3;i++)
+      Matrix3d msh = -skew(m.h());
+      for(unsigned int i=0; i<3; ++i)
         r[i+3] = msh(i,0)*a.S()[0]+
-          msh(i,1)*a.S()[1]+
-          msh(i,2)*a.S()[2];
+                 msh(i,1)*a.S()[1]+
+                 msh(i,2)*a.S()[2];
       return r;
-    }
-
-    inline Vector6d operator*(const Inertia & m,
-                              const ConstraintMotionAnyAxis &a)
-    {
-      OperatorMul<Vector6d,Inertia, ConstraintMotionAnyAxis > om;
-      return om.mul(m,a);
     }
   }
 }

--- a/include/metapod/tools/spatial/cm-freeflyer.hh
+++ b/include/metapod/tools/spatial/cm-freeflyer.hh
@@ -58,24 +58,14 @@ namespace metapod
       Matrix6d m_S;
     };
 
-    template<> inline
-    Matrix6d OperatorMul< Matrix6d, Inertia, ConstraintMotionFreeFlyer>::
-      mul(const Inertia & m,
-          const ConstraintMotionFreeFlyer &a) const
-    {
-      Matrix6d r(Matrix6d::Zero());
+    inline Matrix6d operator*(const Inertia &m,
+                              const ConstraintMotionFreeFlyer &a) {
+      Matrix6d r;
       r.block<3,3>(0,0) = skew(m.h())*a.S().block<3,3>(3,0);
       r.block<3,3>(0,3) = m.I()*static_cast<Matrix3d>(a.S().block<3,3>(0,3));
       r.block<3,3>(3,0) = m.m()*a.S().block<3,3>(3,0);
       r.block<3,3>(3,3) = -skew(m.h())*a.S().block<3,3>(0,3);
       return r;
-    }
-
-    inline Matrix6d operator*(const Inertia & m,
-                              const ConstraintMotionFreeFlyer &a)
-    {
-      OperatorMul<Matrix6d,Inertia, ConstraintMotionFreeFlyer > om;
-      return om.mul(m,a);
     }
   } // End of spatial namespace
 } // End of metapod namespace

--- a/include/metapod/tools/spatial/inertia.hh
+++ b/include/metapod/tools/spatial/inertia.hh
@@ -32,13 +32,19 @@ namespace metapod
       public:
         // Constructors
         Inertia() : m_m(), m_h(), m_I() {}
-        Inertia(FloatType m, const Vector3d & h, const Matrix3d & I)
-          : m_m(m), m_h(h), m_I(I) {}
-        Inertia(FloatType m, const Vector3d & h, const lowerTriangularMatrix & I)
-          : m_m(m), m_h(h), m_I(I) {}
+        Inertia(FloatType m, const Vector3d &h, const Matrix3d &I)
+            : m_m(m),
+              m_h(h),
+              m_I(I) {}
+        Inertia(FloatType m, const Vector3d &h, const lowerTriangularMatrix &I)
+            : m_m(m),
+              m_h(h),
+              m_I(I) {}
 
         // Initializers
-        static const Inertia Zero() { return Inertia(0., Vector3d::Zero(), lowerTriangularMatrix::Zero()); }
+        static const Inertia Zero() {
+          return Inertia(0., Vector3d::Zero(), lowerTriangularMatrix::Zero());
+        }
 
         // Getters
         FloatType m() const { return m_m; }
@@ -56,38 +62,19 @@ namespace metapod
         }
 
         // Arithmetic operators
-
-        Inertia operator+(const Inertia & other) const
-        {
-          return Inertia(m_m+other.m(), m_h+other.h(), m_I+other.I());
+        Inertia operator+(const Inertia &other) const {
+          return Inertia(m_m+other.m_m, m_h+other.m_h, m_I+other.m_I);
         }
 
-
-        friend Inertia operator*(FloatType a, const Inertia & I)
-        {
-          return Inertia(I.m()*a, I.h()*a, I.I()*a);
+        Inertia operator*(const FloatType &a) const {
+          return Inertia(m_m*a, m_h*a, m_I*a);
         }
 
-        // Print operator
-        friend std::ostream & operator << (std::ostream & os, const Inertia & I)
-        {
-          os
-            << "m =\n" << I.m() << std::endl
-            << "h =\n" << I.h() << std::endl
-            << "I =\n" << I.I() << std::endl;
-          return os;
+        Force operator*(const Motion &mv) const {
+          return Force(m_I*mv.w() + m_h.cross(mv.v()),
+                       m_m*mv.v() - m_h.cross(mv.w()));
         }
-      
-      template<class T, class U, class S>
-      friend class OperatorMul;
 
-
-      template<class T, class U, class S>
-      friend T operator*(const U &u,const S & s) 
-      { return OperatorMul<T,U,S>::mul(u,s); }
-
-      
-     
       private:
         // Private members
         FloatType m_m;
@@ -95,35 +82,18 @@ namespace metapod
         lowerTriangularMatrix m_I;
     };
 
-    template<> inline
-    Inertia OperatorMul<Inertia,Inertia,FloatType>::mul(const Inertia & m,
-							const FloatType &a) const
-    {
-      return Inertia(m.m_m*a, m.m_h*a, m.m_I*a);
+    inline std::ostream & operator<< (std::ostream &os, const Inertia &I) {
+      os << "m =\n" << I.m() << "\n"
+         << "h =\n" << I.h() << "\n"
+         << "I =\n" << I.I();
+      return os;
     }
-	
-    inline Inertia operator*(const Inertia & m,
-		      const FloatType &a) 
+
+    inline Inertia operator*(FloatType a, const Inertia &I)
     {
-      OperatorMul<Inertia,Inertia,FloatType> om;
-      return om.mul(m,a);
+      return I * a;
     }
-	
-    /* Operator Force = Inertia * Motion */
-    template<> inline
-    Force OperatorMul<Force,Inertia,Motion>::mul(const Inertia & m,
-						 const Motion &mv) const
-    {
-	  return Force(m.m_I*mv.w() + m.m_h.cross(mv.v()),
-		       m.m_m*mv.v() - m.m_h.cross(mv.w()));
-    }
-    
-    inline Force operator*(const Inertia &m,
-                           const Motion & mv) 
-    {
-      OperatorMul<Force,Inertia,Motion> om;
-      return om.mul(m,mv);
-    }
+
     
   } // end of namespace Spatial
 

--- a/include/metapod/tools/spatial/lti.hh
+++ b/include/metapod/tools/spatial/lti.hh
@@ -33,19 +33,15 @@ namespace metapod
     {
     public:
       ltI(): m_ltI() { }
-      ltI(const Matrix3d &I)
-      {
+      ltI(const Matrix3d &I) {
         m_ltI(0) = I(0,0);
         m_ltI(1) = I(1,0); m_ltI(2) = I(1,1);
         m_ltI(3) = I(2,0); m_ltI(4) = I(2,1); m_ltI(5) = I(2,2);
       }
       ltI(const Vector6d &I):
-        m_ltI(I)
-      {
-      }
+        m_ltI(I) {}
 
-      static ltI Zero()
-      {
+      static ltI Zero() {
         // without the static_cast we get the following error:
         //
         //     error: call of overloaded ‘ltI(const ConstantReturnType)’
@@ -67,11 +63,6 @@ namespace metapod
         ltI a;
         a.m_ltI = m_ltI + altI.m_ltI;
         return a;
-      }
-
-      friend ltI operator*(FloatType a, const ltI& altI)
-      {
-        return ltI(static_cast<Vector6d>(a * altI.m_ltI));
       }
 
       ltI operator*(FloatType a) const
@@ -135,6 +126,12 @@ namespace metapod
     };
 
     typedef ltI lowerTriangularMatrix;
+
+    inline ltI operator*(FloatType a, const ltI& altI)
+    {
+      return altI * a;
+    }
+
 
   }
 }


### PR DESCRIPTION
OperatorMul does not seem to be needed. I'm not sure about why it
was introduced in the first place.

The only point I see is that Inertia could declare the generic
OperatorMul as a friend and hence let future specializations access
its private members. However, all its private members are accessible
through getters, so this does not seem necessary.

Maybe I missed the point, feel free to discuss.

I checked that this change has no performance impact.
