### PR TITLE
metapodfromurdf: fix inertia matrix rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ directory:
 
     mkdir _build
     cd _build
-    cmake -DBUILD_METAPODFROMURDF=OFF
+    cmake -DBUILD_METAPODFROMURDF=OFF ..
     make install
 
 Please note that CMake produces a `CMakeCache.txt` file which should

--- a/metapodfromurdf/src/metapodfromurdf.cpp
+++ b/metapodfromurdf/src/metapodfromurdf.cpp
@@ -180,7 +180,7 @@ Status addSubTree(
     tmp << root->inertial->ixx, root->inertial->ixy, root->inertial->ixz,
       root->inertial->ixy, root->inertial->iyy, root->inertial->iyz,
       root->inertial->ixz, root->inertial->iyz, root->inertial->izz;
-    rotational_inertia = R * tmp;
+    rotational_inertia.noalias() = R * tmp * R.transpose();
   }
   int dof_index = -1;
   std::map<std::string, int>::const_iterator it =


### PR DESCRIPTION
This bug went unoticed since both simple_{arm,humanoid} urdf models have
identity rotation matrices.

Many thanks to Joseph Salini for the report, the fix and the testing ;)

Change-Id: I3531fd47f01ed52574eec64d3929aaf45080f753
