### PR TITLE
Fix error in methods apply(Motion) and apply(Force) of class Transform: ...

### DIFF
--- a/include/metapod/tools/spatial/transform.hh
+++ b/include/metapod/tools/spatial/transform.hh
@@ -74,13 +74,13 @@ class TransformT_helper
   Motion apply(const Motion & mv) const
   {
     return Motion(m_E * mv.w(),
-                             m_E * (mv.v() - m_r.cross(mv.w())));
+                             m_E * (mv.v() - m_r.cross(mv.w())).eval());
   }
 
   /// Fb = bXa.apply(Fa)
   Force apply(const Force & fv) const
   {
-    return Force(m_E*(fv.n() - m_r.cross(fv.f())), m_E*fv.f());
+    return Force(m_E*(fv.n() - m_r.cross(fv.f())).eval(), m_E*fv.f());
   }
 
   /// Ib = bXa.apply(Ia)

--- a/tests/spatial/test_transform.cc
+++ b/tests/spatial/test_transform.cc
@@ -46,6 +46,38 @@ struct TestTransform
     TransformT<FloatType, typename rm_mul_op<FloatType, RotationClass, RotationMatrixIdentity >::rm > sXp;
     sXp = Xj *Xt;
     std::cout  << sXp << std::endl;
+
+    Force f;
+    Xj.apply(f);
+    Xj.applyInv(f);
+    Xt.apply(f);
+    Xt.applyInv(f);
+    sXp.apply(f);
+    sXp.applyInv(f);
+
+    Motion m;
+    Xj.apply(m);
+    Xj.applyInv(m);
+    Xt.apply(m);
+    Xt.applyInv(m);
+    sXp.apply(m);
+    sXp.applyInv(m);
+
+    Inertia I;
+    Xj.apply(I);
+    Xj.applyInv(I);
+    Xt.apply(I);
+    Xt.applyInv(I);
+    sXp.apply(I);
+    sXp.applyInv(I);
+
+    Vector3d v;
+    Xj.apply(v);
+    Xj.applyInv(v);
+    Xt.apply(v);
+    Xt.applyInv(v);
+    sXp.apply(v);
+    sXp.applyInv(v);
   }
 };
 


### PR DESCRIPTION
The fixed error was "ambiguous call to operator*()". Add associated tests in test_transform. 
Add also a test for apply(Vector3d) and apply(Inertia); the last one is NOT WORKING, the error is 'no matching function for call skew(const Vector3d)'.
